### PR TITLE
Add travis ci build badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+/vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: php
+
+# Use container-based infrastructure
+sudo: false
+
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+
+before_script:
+  - composer self-update
+  - composer install
+
+script: vendor/bin/phpunit
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Zalo SDK for PHP (v1.0.2)
+[![Build Status](https://travis-ci.org/zaloplatform/zalo-php-sdk.svg?branch=master)](https://travis-ci.org/zaloplatform/zalo-php-sdk)
 
 ## Installation
 


### PR DESCRIPTION
Add Travis CI build config and badge status to README file. See https://travis-ci.org/hungneox/zalo-php-sdk

Currently the build was failed becauswe of `Fatal error: Class 'Buonzz\Template\YourClass' not found`. I suggest that we enable travis ci for this repo to improve general quality.
