### PR TITLE
fix bug Undefined offset: 1 when create GraphRawResponse

### DIFF
--- a/src/Http/GraphRawResponse.php
+++ b/src/Http/GraphRawResponse.php
@@ -87,8 +87,9 @@ class GraphRawResponse
      */
     public function setHttpResponseCodeFromHeader($rawResponseHeader)
     {
-        preg_match('|HTTP/\d\.\d\s+(\d+)\s+.*|', $rawResponseHeader, $match);
-        $this->httpResponseCode = (int)$match[1];
+        if (preg_match("/^HTTP.*(\d+)$/", trim($rawResponseHeader), $match) && isset($match[1])) {
+            $this->httpResponseCode = intval($match[1]);
+        }
     }
 
     /**


### PR DESCRIPTION
fix bug Undefined offset: 1 when create GraphRawResponse

fix for issue [#14](https://github.com/zaloplatform/zalo-php-sdk/issues/14)