### PR TITLE
Change type to library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
             "email": "zaloplatform@gmail.com"
         }
     ],
-    "type": "project",
+    "type": "library",
     "require": {
 		"php": ">=5.4"
     },


### PR DESCRIPTION
Hiển thị trên trang https://packagist.org là composer require zaloplatform/zalo-php-sdk thay vì composer create-project zaloplatform/zalo-php-sdk